### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "python3"
+run = ""

--- a/README.md
+++ b/README.md
@@ -6,3 +6,4 @@ project can be installed using the .EXE installer for the text based version, ot
 
 this project will log information regarding the key used and the translated message in both a csv and txt file.
 
+[![Run on Repl.it](https://repl.it/badge/github/nick17773/ProgrammingAssesment2.7)](https://repl.it/github/nick17773/ProgrammingAssesment2.7)


### PR DESCRIPTION
This pull request adds a `Run on Repl.it` badge to the `README`. This will allow users to easily run this repository in their browser, without having to set up an environment. You can learn more about Repl.it [here](https://repl.it).